### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the GitHub Skills activity that was announced by the principal.

## What changed
- Added GitHub Skills activity to the available activities list
- Includes description about GitHub Certifications program and college applications
- Schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM  
- Capacity: 25 participants

## Fixes
Closes #6